### PR TITLE
Fix #5 by preventing painting when the RenderLocalHeroLeaderLayer is detached

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,10 +28,6 @@ dependencies:
   equatable: ^2.0.3
 
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/src/rendering/local_hero_layer.dart
+++ b/lib/src/rendering/local_hero_layer.dart
@@ -29,6 +29,9 @@ class RenderLocalHeroLeaderLayer extends RenderProxyBox {
   }
 
   void _onAnimationStatusChanged(AnimationStatus status) {
+    if (!attached) {
+      return;
+    }
     if (status == AnimationStatus.completed ||
         status == AnimationStatus.dismissed) {
       markNeedsPaint();


### PR DESCRIPTION
The failed assertion (`!_debugDisposed is not true`) from #5 comes from the animation status listener of `RenderLocalHeroLeaderLayer`. It marks itself for paint when the animation finishes despite already being disposed.

The PR #14 attempts to solve the same issue but relies on the `debugDisposed` which should not be used outside `assert`.

The check can be done using the [`attached`](https://api.flutter.dev/flutter/rendering/RenderObject/attached.html) property.

Also removed an unused dependency from the example.