### PR TITLE
fix: should not flicker

### DIFF
--- a/lib/src/rendering/local_hero_layer.dart
+++ b/lib/src/rendering/local_hero_layer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:local_hero/src/rendering/controller.dart';
 import 'package:local_hero/src/rendering/layer.dart';
 
@@ -144,6 +145,16 @@ class RenderLocalHeroFollowerLayer extends RenderProxyBox {
         : constraints.enforce(BoxConstraints.tight(requestedSize));
     child!.layout(childConstraints, parentUsesSize: true);
     size = constraints.constrain(child!.size);
+
+    if (requestedSize == null) {
+      // The size is not known yet, let's wait for the next frame.
+      // This happens e.g. when the widget is animated (e.g. flutter_animate).
+      // Removing this "workaround" will result in a flickering effect where the
+      // first frame of the animation takes the full size of the LocalHeroScope.
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        markNeedsLayout();
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
When the widget is initially not visible, then there is one frame where the animated widget takes the full screen.

Reproduction code:

```dart
class FlickeringTestWidget extends StatefulWidget {
  const FlickeringTestWidget({super.key});

  @override
  State<FlickeringTestWidget> createState() => _FlickeringTestWidgetState();
}

class _FlickeringTestWidgetState extends State<FlickeringTestWidget> {
  double topPadding = 0;
  bool visible = false;

  @override
  void initState() {
    super.initState();

    Future.delayed(const Duration(milliseconds: 1000), () {
      setState(() {
        visible = true;
      });
    });

    Future.delayed(const Duration(milliseconds: 2000), () {
      setState(() {
        topPadding = 100;
      });
    });
  }

  @override
  Widget build(BuildContext context) {
    return Opacity(
      opacity: visible ? 1 : 0,
      child: LocalHeroScope(
        child: Align(
          alignment: Alignment.topLeft,
          child: Padding(
            padding: EdgeInsets.only(top: topPadding),
            child: LocalHero(
              tag: 'id',
              child: Container(
                width: 100,
                height: 100,
                color: Colors.red,
              ),
            ),
          ),
        ),
      ),
    );
  }
}

```